### PR TITLE
textarea, placeholder からインデント、改行を削除

### DIFF
--- a/resources/views/components/tweet/form/post.blade.php
+++ b/resources/views/components/tweet/form/post.blade.php
@@ -19,8 +19,7 @@
             rounded-md
             p-2
             "
-          placeholder="つぶやきを入力">
-        </textarea>
+          placeholder="つぶやきを入力"></textarea>
       </div>
 
       <p class="


### PR DESCRIPTION
コードの見やすさを意識して、textarea, placeholder の部分に改行やインデントを入れると、それがそのまま表示されてしまうため、削除